### PR TITLE
Add a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Early Semantic Versioning](https://docs.scala-lang.org/overviews/core/binary-compatibility-for-library-authors.html#recommended-versioning-scheme) in addition to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2022-06-07
+
+The initial release of this project, containing linting rules to detect `.map(f).sequence` function call chains, and to detect discarded IO expressions.
+
+[Unreleased]: https://github.com/typelevel/typelevel-scalafix/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/typelevel/typelevel-scalafix/releases/tag/v0.1.0


### PR DESCRIPTION
Not sure what others think about keeping a changelog in this format, but I have used it in sbt-tpolecat and it is pretty lighweight. I generally just copy the changelog entries into the GitHub release description.