### PR TITLE
Add an aggregate module to publish all rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p modules/cats/output/target target/cats-effect-aggregate/target modules/cats/tests/target modules/cats-effect/tests/target modules/cats-effect/rules/target target modules/cats-effect/input/target modules/cats/rules/target modules/cats-effect/output/target target/cats-aggregate/target modules/cats/input/target project/target
+        run: mkdir -p modules/cats/output/target target/cats-effect-aggregate/target modules/cats/tests/target modules/cats-effect/tests/target target/rules-aggregate/target modules/cats-effect/rules/target target modules/cats-effect/input/target modules/cats/rules/target modules/cats-effect/output/target target/cats-aggregate/target modules/cats/input/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar modules/cats/output/target target/cats-effect-aggregate/target modules/cats/tests/target modules/cats-effect/tests/target modules/cats-effect/rules/target target modules/cats-effect/input/target modules/cats/rules/target modules/cats-effect/output/target target/cats-aggregate/target modules/cats/input/target project/target
+        run: tar cf targets.tar modules/cats/output/target target/cats-effect-aggregate/target modules/cats/tests/target modules/cats-effect/tests/target target/rules-aggregate/target modules/cats-effect/rules/target target modules/cats-effect/input/target modules/cats/rules/target modules/cats-effect/output/target target/cats-aggregate/target modules/cats/input/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,13 @@ ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaV
 
 lazy val `typelevel-scalafix` = project
   .in(file("."))
-  .aggregate(cats, catsEffect)
+  .aggregate(`typelevel-scalafix-rules`, cats, catsEffect)
   .enablePlugins(NoPublishPlugin)
+
+lazy val `typelevel-scalafix-rules` = project
+  .in(file("target/rules-aggregate"))
+  .dependsOn(catsRules, catsEffectRules)
+  .settings(moduleName := "typelevel-scalafix")
 
 // typelevel/cats Scalafix rules
 lazy val cats =

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,10 @@ lazy val `typelevel-scalafix` = project
 lazy val `typelevel-scalafix-rules` = project
   .in(file("target/rules-aggregate"))
   .dependsOn(catsRules, catsEffectRules)
-  .settings(moduleName := "typelevel-scalafix")
+  .settings(
+    moduleName := "typelevel-scalafix",
+    tlVersionIntroduced ++= List("2.12", "2.13").map(_ -> "0.1.2").toMap
+  )
 
 // typelevel/cats Scalafix rules
 lazy val cats =


### PR DESCRIPTION
Wow, that was way more awkward than I expected - I might have got something wrong here, but I think that aggregate of an aggregate module does not depend on the dependencies of its aggregated subprojects when you turn on publishing, so I couldn't just turn off `NoPublishPlugin` on the root project as `cats` and `catsEffect` projects are themselves aggregate projects.