### PR TITLE
Create FS2 module, add `SyncCompiler` rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p modules/cats/output/target target/cats-effect-aggregate/target modules/cats/tests/target modules/cats-effect/tests/target target/rules-aggregate/target modules/cats-effect/rules/target target modules/cats-effect/input/target modules/cats/rules/target modules/cats-effect/output/target target/cats-aggregate/target modules/cats/input/target project/target
+        run: mkdir -p modules/cats/output/target target/fs2-aggregate/target target/cats-effect-aggregate/target modules/fs2/rules/target modules/cats/tests/target modules/fs2/tests/target modules/cats-effect/tests/target target/rules-aggregate/target modules/cats-effect/rules/target target modules/fs2/output/target modules/fs2/input/target modules/cats-effect/input/target modules/cats/rules/target modules/cats-effect/output/target target/cats-aggregate/target modules/cats/input/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar modules/cats/output/target target/cats-effect-aggregate/target modules/cats/tests/target modules/cats-effect/tests/target target/rules-aggregate/target modules/cats-effect/rules/target target modules/cats-effect/input/target modules/cats/rules/target modules/cats-effect/output/target target/cats-aggregate/target modules/cats/input/target project/target
+        run: tar cf targets.tar modules/cats/output/target target/fs2-aggregate/target target/cats-effect-aggregate/target modules/fs2/rules/target modules/cats/tests/target modules/fs2/tests/target modules/cats-effect/tests/target target/rules-aggregate/target modules/cats-effect/rules/target target modules/fs2/output/target modules/fs2/input/target modules/cats-effect/input/target modules/cats/rules/target modules/cats-effect/output/target target/cats-aggregate/target modules/cats/input/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ rules = [
   TypelevelUnusedIO
   TypelevelMapSequence
   TypelevelUnusedShowInterpolator
-  TypelevelSyncCompiler
+  TypelevelFs2SyncCompiler
 ]
 ```
 
@@ -116,7 +116,7 @@ IO.println("foo").timeout(50.millis).attemptNarrow[TimeoutException]
 
 ## Rules for fs2
 
-### TypelevelSyncCompiler
+### TypelevelFs2SyncCompiler
 
 This rule detects usages of the fs2 `Sync` compiler which can have surprising semantics with regard to (lack of) interruption (e.g., [typelevel/fs2#2371](https://github.com/typelevel/fs2/issues/2371)).
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix" % "0
 ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix-cats" % "0.1.4"
 // To add only cats-effect Scalafix rules
 ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix-cats-effect" % "0.1.4"
+// To add only fs2 Scalafix rules
+ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix-fs2" % "0.1.4"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ rules = [
   TypelevelUnusedIO
   TypelevelMapSequence
   TypelevelUnusedShowInterpolator
+  TypelevelSyncCompiler
 ]
 ```
 
@@ -109,6 +110,22 @@ EitherT(IO.println("foo").attempt).value
 
 // .attemptNarrow is provided as a `cats.ApplicativeError` extension method
 IO.println("foo").timeout(50.millis).attemptNarrow[TimeoutException]
+```
+
+## Rules for fs2
+
+### TypelevelSyncCompiler
+
+This rule detects usages of the fs2 `Sync` compiler which can have surprising semantics with regard to (lack of) interruption (e.g., [typelevel/fs2#2371](https://github.com/typelevel/fs2/issues/2371)).
+
+**Examples**
+
+```scala
+def countChunks[F[_]: Sync, A](stream: Stream[F, A]): F[Long] =
+  stream.chunks.as(1L).compile.foldMonoid /*
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  FS2's Sync compiler should be avoided due to its surprising semantics.
+  Usually this means a Sync constraint needs to be changed to Concurrent or upgraded to Async. */
 ```
 
 ## Conduct

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ ThisBuild / scalaVersion       := (ThisBuild / crossScalaVersions).value.head
 
 lazy val CatsVersion       = "2.7.0"
 lazy val CatsEffectVersion = "3.3.11"
+lazy val Fs2Version        = "3.2.8"
 
 ThisBuild / developers ++= List(
   tlGitHubDev("DavidGregory084", "David Gregory")
@@ -16,12 +17,12 @@ ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaV
 
 lazy val `typelevel-scalafix` = project
   .in(file("."))
-  .aggregate(`typelevel-scalafix-rules`, cats.all, catsEffect.all)
+  .aggregate(`typelevel-scalafix-rules`, cats.all, catsEffect.all, fs2.all)
   .enablePlugins(NoPublishPlugin)
 
 lazy val `typelevel-scalafix-rules` = project
   .in(file("target/rules-aggregate"))
-  .dependsOn(cats.rules, catsEffect.rules)
+  .dependsOn(cats.rules, catsEffect.rules, fs2.rules)
   .settings(
     moduleName := "typelevel-scalafix",
     tlVersionIntroduced ++= List("2.12", "2.13").map(_ -> "0.1.2").toMap,
@@ -43,5 +44,15 @@ lazy val catsEffect = scalafixProject("cats-effect")
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core"   % CatsVersion,
       "org.typelevel" %% "cats-effect" % CatsEffectVersion
+    )
+  )
+
+// typelevel/fs2 Scalafix rules
+lazy val fs2 = scalafixProject("fs2")
+  .inputSettings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core"   % CatsVersion,
+      "org.typelevel" %% "cats-effect" % CatsEffectVersion,
+      "org.typelevel" %% "fs2-core"    % Fs2Version
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val catsEffect = scalafixProject("cats-effect")
 // typelevel/fs2 Scalafix rules
 lazy val fs2 = scalafixProject("fs2")
   .inputSettings(
+    semanticdbOptions += "-P:semanticdb:synthetics:on",
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core"   % CatsVersion,
       "org.typelevel" %% "cats-effect" % CatsEffectVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,6 @@ lazy val fs2 = scalafixProject("fs2")
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core"   % CatsVersion,
       "org.typelevel" %% "cats-effect" % CatsEffectVersion,
-      "org.typelevel" %% "fs2-core"    % Fs2Version
+      "co.fs2"        %% "fs2-core"    % Fs2Version
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,9 @@ lazy val catsEffect = scalafixProject("cats-effect")
 
 // typelevel/fs2 Scalafix rules
 lazy val fs2 = scalafixProject("fs2")
+  .rulesSettings(
+    tlVersionIntroduced ++= List("2.12", "2.13").map(_ -> "0.1.5").toMap
+  )
   .inputSettings(
     semanticdbOptions += "-P:semanticdb:synthetics:on",
     libraryDependencies ++= Seq(

--- a/modules/fs2/input/src/main/scala/fix/SyncCompilerTest.scala
+++ b/modules/fs2/input/src/main/scala/fix/SyncCompilerTest.scala
@@ -1,0 +1,16 @@
+/*
+rule = TypelevelSyncCompiler
+ */
+
+package fix
+
+import cats.effect._
+import fs2._
+
+object Fs2SyncCompilerTest {
+  def usesSyncInnocently[F[_]](implicit F: Sync[F]) = F.delay(println("hi"))
+  def usesSyncCompiler[F[_]](implicit F: Sync[F]) =
+    Stream(1, 2, 3).covary[F].compile.drain // assert: TypelevelSyncCompiler.syncCompiler
+  def usesConcurrentCompiler[F[_]](implicit F: Concurrent[F]) =
+    Stream(1, 2, 3).covary[F].compile.drain
+}

--- a/modules/fs2/input/src/main/scala/fix/SyncCompilerTest.scala
+++ b/modules/fs2/input/src/main/scala/fix/SyncCompilerTest.scala
@@ -1,5 +1,5 @@
 /*
-rule = TypelevelSyncCompiler
+rule = TypelevelFs2SyncCompiler
  */
 
 package fix
@@ -10,7 +10,7 @@ import fs2._
 object Fs2SyncCompilerTest {
   def usesSyncInnocently[F[_]](implicit F: Sync[F]) = F.delay(println("hi"))
   def usesSyncCompiler[F[_]](implicit F: Sync[F]) =
-    Stream(1, 2, 3).covary[F].compile.drain // assert: TypelevelSyncCompiler.syncCompiler
+    Stream(1, 2, 3).covary[F].compile.drain // assert: TypelevelFs2SyncCompiler.syncCompiler
   def usesConcurrentCompiler[F[_]](implicit F: Concurrent[F]) =
     Stream(1, 2, 3).covary[F].compile.drain
 }

--- a/modules/fs2/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/modules/fs2/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+org.typelevel.fix.SyncCompiler

--- a/modules/fs2/rules/src/main/scala/org/typelevel/fix/SyncCompiler.scala
+++ b/modules/fs2/rules/src/main/scala/org/typelevel/fix/SyncCompiler.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.fix
+
+import scalafix.v1._
+
+import scala.meta._
+
+class SyncCompiler extends SemanticRule("TypelevelSyncCompiler") {
+  override def fix(implicit doc: SemanticDocument): Patch =
+    doc.tree.collect { case Stream_compile_M(t @ Term.Select(_, _)) =>
+      t.synthetics.collect { case ApplyTree(_, List(ApplyTree(_, List(target)))) =>
+        target.symbol.collect { case Target_forSync_M(_) =>
+          Patch.lint(SyncCompiler.SyncCompilerDiagnostic(t))
+        }.asPatch
+      }.asPatch
+    }.asPatch
+
+  val Stream_compile_M = SymbolMatcher.exact("fs2/Stream#compile().")
+  val Target_forSync_M = SymbolMatcher.exact("fs2/Compiler.TargetLowPriority#forSync().")
+}
+
+object SyncCompiler {
+
+  final case class SyncCompilerDiagnostic(t: Tree) extends Diagnostic {
+    override def message: String =
+      "FS2's Sync compiler should be avoided due to its surprising semantics. Usually this means a Sync constraint needs to be changed to Concurrent or upgraded to Async."
+
+    override def position: Position = t.pos
+
+    override def categoryID: String = "syncCompiler"
+  }
+
+}

--- a/modules/fs2/rules/src/main/scala/org/typelevel/fix/SyncCompiler.scala
+++ b/modules/fs2/rules/src/main/scala/org/typelevel/fix/SyncCompiler.scala
@@ -20,7 +20,7 @@ import scalafix.v1._
 
 import scala.meta._
 
-class SyncCompiler extends SemanticRule("TypelevelSyncCompiler") {
+class SyncCompiler extends SemanticRule("TypelevelFs2SyncCompiler") {
   override def fix(implicit doc: SemanticDocument): Patch =
     doc.tree.collect { case Stream_compile_M(t @ Term.Select(_, _)) =>
       t.synthetics.collect { case ApplyTree(_, List(ApplyTree(_, List(target)))) =>

--- a/modules/fs2/tests/src/test/scala/org/typelevel/fix/RuleSuite.scala
+++ b/modules/fs2/tests/src/test/scala/org/typelevel/fix/RuleSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.fix
+
+import scalafix.testkit._
+import org.scalatest.FunSuiteLike
+
+class RuleSuite extends AbstractSemanticRuleSuite with FunSuiteLike {
+  runAllTests()
+}


### PR DESCRIPTION
Part of https://github.com/typelevel/typelevel-scalafix/issues/1. This upstreams the `SyncCompiler` rule from http4s written by @bplommer.

https://github.com/http4s/http4s/blob/cc9bf545feedebbf3f59e8b57f29b8be8baf1681/scalafix-internal/rules/src/main/scala-2/fix/Fs2Linters.scala

I feel uneasy about naming, so let's please bikeshed that 🙏 