### PR TITLE
Use atomic where applicable

### DIFF
--- a/modules/http4s/input/src/main/scala/fix/LiteralsSyntaxWithSuppresionsTests.scala
+++ b/modules/http4s/input/src/main/scala/fix/LiteralsSyntaxWithSuppresionsTests.scala
@@ -1,0 +1,21 @@
+/*
+rule = TypelevelHttp4sLiteralsSyntax
+ */
+
+package fix
+
+import org.http4s.Uri
+
+object LiteralsSyntaxWithSuppresionsTests {
+  val s = "foo.com"
+
+  // scalafix:off
+  Uri.unsafeFromString("foo.com")
+  Uri.unsafeFromString("""foo.com""")
+  Uri.unsafeFromString("foo" + ".com")
+  Uri.unsafeFromString(s)
+  Uri.unsafeFromString(s"http://$s")
+
+  Uri.Path.unsafeFromString("foo/bar")
+  // scalafix:on
+}

--- a/modules/http4s/output/src/main/scala/fix/LiteralsSyntaxWithSuppresionsTests.scala
+++ b/modules/http4s/output/src/main/scala/fix/LiteralsSyntaxWithSuppresionsTests.scala
@@ -1,0 +1,17 @@
+package fix
+
+import org.http4s.Uri
+
+object LiteralsSyntaxWithSuppresionsTests {
+  val s = "foo.com"
+
+  // scalafix:off
+  Uri.unsafeFromString("foo.com")
+  Uri.unsafeFromString("""foo.com""")
+  Uri.unsafeFromString("foo" + ".com")
+  Uri.unsafeFromString(s)
+  Uri.unsafeFromString(s"http://$s")
+
+  Uri.Path.unsafeFromString("foo/bar")
+  // scalafix:on
+}

--- a/modules/http4s/rules/src/main/scala/org/typelevel/fix/Http4sLiteralsSyntax.scala
+++ b/modules/http4s/rules/src/main/scala/org/typelevel/fix/Http4sLiteralsSyntax.scala
@@ -27,12 +27,12 @@ class Http4sLiteralsSyntax extends SemanticRule("TypelevelHttp4sLiteralsSyntax")
             Uri_unsafeFromString_M(_),
             List(lit @ Lit.String(_))
           ) =>
-        Patch.replaceTree(t, s"uri$lit") + importLiteralsIfNeeded
+        (Patch.replaceTree(t, s"uri$lit") + importLiteralsIfNeeded).atomic
       case t @ Term.Apply(
             Path_unsafeFromString_M(_),
             List(lit @ Lit.String(_))
           ) =>
-        Patch.replaceTree(t, s"path$lit") + importLiteralsIfNeeded
+        (Patch.replaceTree(t, s"path$lit") + importLiteralsIfNeeded).atomic
     }.asPatch
 
   val Uri_unsafeFromString_M  = SymbolMatcher.exact("org/http4s/Uri.unsafeFromString().")


### PR DESCRIPTION
Hi! This PR makes the `Http4sLiteralsSyntax` (I believe this is the only applicable rule) rule mark its patches as atomic using [.atomic](https://scalacenter.github.io/scalafix/docs/developers/patch.html#atomic) which makes the rule respect supressions, and is also used by the scalafix api to group patches.

Thanks!