### PR TITLE
Readme updates: rule compatibilties + fs2 sync compiler instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ IO.println("foo").timeout(50.millis).attemptNarrow[TimeoutException]
 
 This rule detects usages of the fs2 `Sync` compiler which can have surprising semantics with regard to (lack of) interruption (e.g., [typelevel/fs2#2371](https://github.com/typelevel/fs2/issues/2371)).
 
+To use this rule, you'll need to enable synthetics by adding the following to your `build.sbt`:
+```scala
+ThisBuild / semanticdbOptions += "-P:semanticdb:synthetics:on"
+```
+
+
 **Examples**
 
 ```scala

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ rules = [
 > scalafix TypelevelUnusedIO
 ```
 
+### Scala compatibility
+
+Not all rules function with Scala 3 yet.
+
+| Rule                            | 2.13.x             | 3.x                |
+|---------------------------------|--------------------|--------------------|
+| TypelevelUnusedIO               | :white_check_mark: | :x:                |
+| TypelevelMapSequence            | :white_check_mark: | :white_check_mark: |
+| TypelevelAs                     | :white_check_mark: | :white_check_mark: |
+| TypelevelUnusedShowInterpolator | :white_check_mark: | :x:                |
+| TypelevelFs2SyncCompiler        | :white_check_mark: | :x:                |
+| TypelevelHttp4sLiteralsSyntax   | :white_check_mark: | :white_check_mark: |
+
 ## Rules for cats
 
 ### TypelevelMapSequence


### PR DESCRIPTION
- adds a little table showing the current scala 3 compatibility for all the rules.
  - I'm not sure if the rules could easily be updated to support scala 3. This is just what I found in my experiments at `$work`
- documents the synthetics flag necessary (??) for the fs2 sync compiler rule
  - I had to enable synthetics to get this rule to work in my experiments, and I figured that out via this comment: https://github.com/typelevel/typelevel-scalafix/pull/22#issuecomment-1156785378