### PR TITLE
Update TypelevelIORandomUUID scala versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ Not all rules function with Scala 3 yet.
 | Rule                            | 2.13.x             | 3.x                |
 |---------------------------------|--------------------|--------------------|
 | TypelevelUnusedIO               | :white_check_mark: | :x:                |
+| TypelevelIORandomUUID           | :white_check_mark: | :white_check_mark: |
 | TypelevelMapSequence            | :white_check_mark: | :white_check_mark: |
 | TypelevelAs                     | :white_check_mark: | :white_check_mark: |
 | TypelevelUnusedShowInterpolator | :white_check_mark: | :x:                |
 | TypelevelFs2SyncCompiler        | :white_check_mark: | :x:                |
 | TypelevelHttp4sLiteralsSyntax   | :white_check_mark: | :white_check_mark: |
-| TypelevelIORandomUUID           | :white_check_mark: | :x:                |
 
 ## Rules for cats
 


### PR DESCRIPTION
The new rule looks great! I've been doing some testing, and so far the rule does work/rewrite in scala 3 so I'm proposing we update the readme. (I also reorganized so the cats-effect rules are together)

Tagging @brbrown25 just in case I'm missing something