### PR TITLE
Linter for `.as(())` => `.void`

### DIFF
--- a/modules/cats/input/src/main/scala/fix/AsTests.scala
+++ b/modules/cats/input/src/main/scala/fix/AsTests.scala
@@ -3,6 +3,8 @@ rule = TypelevelAs
  */
 package fix
 
+import cats.syntax.functor.toFunctorOps
+
 object AsTests {
 
   def listMapLit = {
@@ -17,11 +19,18 @@ object AsTests {
     .map(_ => ()) can be replaced by .void */
   }
 
+  def listAsUnit = {
+    List(1, 2, 3).as(()) /* assert: TypelevelAs.as
+    ^^^^^^^^^^^^^^^^^^^^
+    .as(()) can be replaced by .void */
+  }
+
   def shouldBeIgnored = {
     def f = "a"
     List(1, 2, 3).map(_ => f)
     List(1, 2, 3).map(i => i)
     List(1, 2, 3).map(println(_))
+    List(1, 2, 3).as(1)
   }
 
 }


### PR DESCRIPTION
This is absolutely my first scalafix rule contribution, so please review it with extra care 😇

I think that this rule might have a non zero false-positive ratio, as (I think) it will match ALL the method/functions called `as(())`, not just the one available in cats functor, but I don't know if this is acceptable.

@DavidGregory084 I'm requesting you as a reviewer as I saw that you've implemented a good number of rules in this repo.