### PR TITLE
Add TypelevelEitherSyntax Rule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,8 @@ ThisBuild / developers ++= List(
   tlGitHubDev("DavidGregory084", "David Gregory")
 )
 
-ThisBuild / semanticdbEnabled          := true
-ThisBuild / semanticdbVersion          := scalafixSemanticdb.revision
-ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 
 lazy val `typelevel-scalafix` = project
   .in(file("."))
@@ -35,6 +34,11 @@ lazy val `typelevel-scalafix-rules` = project
 // typelevel/cats Scalafix rules
 lazy val cats = scalafixProject("cats")
   .inputSettings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core" % CatsVersion
+    )
+  )
+  .outputSettings(
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % CatsVersion
     )

--- a/modules/cats/input/src/main/scala/fix/EitherSyntax.scala
+++ b/modules/cats/input/src/main/scala/fix/EitherSyntax.scala
@@ -1,0 +1,16 @@
+/*
+rule = TypelevelEitherSyntax
+ */
+package fix
+
+object EitherSyntax {
+
+  def shouldBeReplaced = {
+    Right(())
+  }
+
+  def shouldBeIgnored = {
+    Right(1)
+  }
+
+}

--- a/modules/cats/output/src/main/scala/fix/EitherSyntax.scala
+++ b/modules/cats/output/src/main/scala/fix/EitherSyntax.scala
@@ -1,0 +1,14 @@
+package fix
+
+import cats.syntax.either._
+object EitherSyntax {
+
+  def shouldBeReplaced = {
+    Either.unit
+  }
+
+  def shouldBeIgnored = {
+    Right(1)
+  }
+
+}

--- a/modules/cats/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/modules/cats/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,3 +1,4 @@
 org.typelevel.fix.MapSequence
 org.typelevel.fix.UnusedShowInterpolator
 org.typelevel.fix.As
+org.typelevel.fix.EitherSyntax

--- a/modules/cats/rules/src/main/scala/org/typelevel/fix/EitherSyntax.scala
+++ b/modules/cats/rules/src/main/scala/org/typelevel/fix/EitherSyntax.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.fix
+
+import scalafix.v1._
+import scala.meta._
+import scala.collection.mutable.ListBuffer
+
+class EitherSyntax extends SemanticRule("TypelevelEitherSyntax") {
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    var docContainsImports: Boolean = false
+    val patches: ListBuffer[Patch]  = ListBuffer.empty[Patch]
+
+    doc.tree.traverse {
+      case ImportCatsSyntaxAll(_) =>
+        docContainsImports = true
+      case ImportCatsSyntaxEither(_) =>
+        docContainsImports = true
+      case expr @ Term.Apply.After_4_6_0(Term.Name("Right"), Term.ArgClause(List(Lit.Unit()), _)) =>
+        if (!docContainsImports)
+          patches.addOne(
+            Patch.addGlobalImport(
+              Importer(
+                Term.Select(
+                  Term.Select(Term.Name("cats"), Term.Name("syntax")),
+                  Term.Name("either")
+                ),
+                List(Importee.Wildcard())
+              )
+            )
+          )
+        patches.addOne(Patch.replaceTree(expr, "Either.unit"))
+    }
+
+    patches.asPatch
+  }
+}
+
+object ImportCatsSyntaxAll {
+  def unapply(t: Tree): Option[String] = t match {
+    case Import(
+          List(
+            Importer(
+              Term.Select(
+                Term.Select(Term.Name("cats"), Term.Name("syntax")),
+                Term.Name("all")
+              ),
+              List(Importee.Wildcard())
+            )
+          )
+        ) =>
+      Some("cats.syntax.all._")
+    case _ => None
+  }
+}
+
+object ImportCatsSyntaxEither {
+  def unapply(t: Tree): Option[String] = t match {
+    case Import(
+          List(
+            Importer(
+              Term.Select(
+                Term.Select(Term.Name("cats"), Term.Name("syntax")),
+                Term.Name("either")
+              ),
+              importee
+            )
+          )
+        ) =>
+      if (
+        importee.exists {
+          case Importee.Wildcard() => true
+          case _                   => false
+        }
+      ) Some("cats.syntax.either._")
+      else if (
+        importee.exists {
+          case Importee.Name(Name.Indeterminate("catsSyntaxEitherObject")) => true
+          case _                                                           => false
+        }
+      ) Some("cats.syntax.either.catsSyntaxEitherObject")
+      else None
+    case _ => None
+  }
+}


### PR DESCRIPTION
I've tried to begin addressing #46.
The solution uses mutability since essentially the APIs ask you to (the only alternative is traversing the entire document multiple times).

The solution is also naive and it's merely syntactical: once it finds the expression `Right(())` searches for one of those imports in any point of the document:

```
cats.syntax.all._
cats.syntax.either._
cats.syntax.either.catsSyntaxEitherObject
```

and if any of those is present it DOESN'T add the `cats.syntax.either._` import.

A nice rework could include:
1) Making the rule semantical, so that we can check that the function called is exactly `scala.util.Right.apply`
2) Searching for every occurrence of the expression if any of those imports is present but starting from it and following the `parent` trees. If any of the occurrences doesn't have those imports in the chain of parent trees then adding a global import is more reasonable (despite the fact that it could always clash with a local import).
